### PR TITLE
Allow string keys in nested interpolations

### DIFF
--- a/test/mustache_feature_test.exs
+++ b/test/mustache_feature_test.exs
@@ -64,6 +64,16 @@ defmodule MustacheFeatureTest do
               %{person: %{name: "Joe"}}) == "\"Joe\" == \"Joe\""
   end
 
+  test "Dotted Names - String Keys" do
+    assert Mustache.render("\"{{person.name}}\" == \"Joe\"",
+              %{"person" => %{"name" => "Joe"}}) == "\"Joe\" == \"Joe\""
+  end
+
+  test "Dotted Names - Mixed Keys" do
+    assert Mustache.render("\"{{person.name}}\" == \"Joe\"",
+              %{"person" => %{name: "Joe"}}) == "\"Joe\" == \"Joe\""
+  end
+
   @tag :pending
   test "Dotted Names - Basic Interpolation" do
     assert Mustache.render("\"{{person.name}}\" == \"{{#person}}{{name}}{{/person}}\"",


### PR DESCRIPTION
And replace `String.to_atom/1` with `String.to_existing_atom/1` for user input.